### PR TITLE
refactor: 重构路由模块，拆分为v1/v2版本

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,18 +6,19 @@ import uvicorn
 import yaml
 from fastapi import FastAPI
 
-from routes import get, post
+from routes import post_v1
+from routes import get_v1
+from routes import post_v2
 from services import init
 from services import config
 from services import utils
 
 logger = logging.getLogger("uvicorn.app")
 
-
 app = FastAPI()
-app.include_router(get.router)
-app.include_router(post.router)
-
+app.include_router(post_v1.router)
+app.include_router(get_v1.router)
+app.include_router(post_v2.router)
 
 if __name__ == "__main__":
     # 初始化日志

--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -1,1 +1,3 @@
-"""API routes package."""
+from .v1 import post_v1
+from .v1 import get_v1
+from .v2 import post_v2

--- a/routes/v1/__init__.py
+++ b/routes/v1/__init__.py
@@ -1,0 +1,2 @@
+from . import get as get_v1
+from . import post as post_v1

--- a/routes/v1/post.py
+++ b/routes/v1/post.py
@@ -3,22 +3,22 @@ import os
 import time
 from typing import Any, Dict
 
-import pandas as pd
+from numpy import real
 from fastapi import APIRouter, status
 
 import services.elements as cfg
 from services import utils
 from services.sql import create_weather_data_table, insert_data, table_exists
 
-router = APIRouter(tags=["post"])
+router = APIRouter(tags=["post","v1"])
 
 logger = logging.getLogger("uvicorn.app")
 
 
-@router.post("/api/upload")
-async def api_upload(item: cfg.meteorological_elements) -> Dict[str, Any]:
+@router.post("/v1/upload")
+async def v1_upload(item: cfg.meteorological_elements):
     """
-    上传站点数据
+    上传站点数据(v1)
 
     参数:
         item: 气象要素数据模型 (meteorological_elements)
@@ -104,25 +104,6 @@ async def sensorlog(item: cfg.location) -> Dict[str, Any]:
         "speed": item.locationSpeed,
     }
 
-    # try:
-    #     df = pd.DataFrame([row])
-    #     df.to_csv(
-    #         file_path,
-    #         index=False,
-    #         header=not os.path.exists(file_path),
-    #         sep=",",
-    #         mode="a",
-    #     )
-    # except Exception as e:
-    #     return {
-    #         "status": status.HTTP_500_INTERNAL_SERVER_ERROR,
-    #         "message": f"write data failed: {e}",
-    #         "data": None,
-    #     }
-
-    # return {"status": status.HTTP_200_OK, "message": "upload success", "data": row}
-
-    
     try:
         if not table_exists(table_name):
             create_weather_data_table(table_name)

--- a/routes/v2/__init__.py
+++ b/routes/v2/__init__.py
@@ -1,0 +1,1 @@
+from . import post as post_v2

--- a/routes/v2/post.py
+++ b/routes/v2/post.py
@@ -1,0 +1,67 @@
+import logging
+import time
+
+from fastapi import APIRouter, status
+
+import services.elements as cfg
+from services import utils
+from services.sql import create_weather_data_table, insert_data, table_exists
+
+router = APIRouter(tags=["post","v2"])
+
+logger = logging.getLogger("uvicorn.app")
+
+
+@router.post("/v2/upload")
+async def v2_upload(item: cfg.meteorological_elements):
+    station_name = item.station_name
+    timestamp = item.timestamp
+    temperature = item.temperature
+    pressure = item.pressure
+    relative_humidity = item.relative_humidity
+    wind_speed = item.wind_speed
+    wind_direction = item.wind_direction
+
+    dew_point = (
+        utils.calc_dew_point(temp_c=temperature, humidity_percent=relative_humidity)
+        if all((temperature, relative_humidity))
+        else None
+    )
+    sea_level_pressure = (
+        utils.calc_sea_level_pressure(
+            temp_c=temperature,
+            pressure_hpa=pressure,
+            humidity_percent=relative_humidity,
+            altitude_m=30.0,
+        )
+        if all((temperature, pressure, relative_humidity))
+        else None
+    )
+
+    row = {
+        "station_name": station_name,
+        "time_utc": time.strftime("%Y-%m-%d %H:%M:%S", time.gmtime(timestamp)),
+        "temperature": temperature,
+        "pressure": pressure,
+        "relative_humidity": relative_humidity,
+        "wind_speed": wind_speed,
+        "wind_direction": wind_direction,
+        "sea_level_pressure": sea_level_pressure,
+        "dew_point": dew_point,
+    }
+
+    day = time.strftime("%Y_%m_%d", time.localtime(timestamp))
+    table_name = f"{station_name}_{day}"
+
+    try:
+        if not table_exists(table_name):
+            create_weather_data_table(table_name)
+        insert_data(table_name, row)
+    except Exception as e:
+        return {
+            "status": status.HTTP_500_INTERNAL_SERVER_ERROR,
+            "message": f"Database write failed: {str(e)}",
+            "data": None,
+        }
+
+    return {"status": status.HTTP_200_OK, "message": "Upload success", "data": row}


### PR DESCRIPTION
## Summary
- 将原有的 `routes/get.py` 和 `routes/post.py` 拆分到 `routes/v1/` 和 `routes/v2/` 目录
- v1 版本包含原有的 GET 和 POST 接口
- v2 版本新增 POST 接口
- 更新 `main.py` 和 `routes/__init__.py` 的导入路径